### PR TITLE
Ensure link target does not get reset

### DIFF
--- a/blocks/link-dropdown/link-dropdown.js
+++ b/blocks/link-dropdown/link-dropdown.js
@@ -9,7 +9,7 @@ function getTitle(block) {
 function getLinks(block) {
   const ul = block.querySelector('ul');
   ul.querySelectorAll('li a').forEach((a) => {
-    a.target = '_self';
+    a.target = a.target ?? '_self';
   });
   return ul;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:

## Issue
Ensute link target does not get reset
Fixes #27 

## Changelog:
Ensute link target does not get reset

## Test URLs:
- Original: https://old.sunstar.com/jp/brands/consumer-health-beauty#kenkodojo
- Before: https://main--sunstar--sunstar-global.hlx.live/jp/brands/consumer-health-beauty#kenkodojo
- After: https://i-27--sunstar--sunstar-global.hlx.live/jp/brands/consumer-health-beauty#kenkodojo

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
