### PR TITLE
Extend 404 handler to handle /# in URL

### DIFF
--- a/404.html
+++ b/404.html
@@ -16,6 +16,16 @@
       window.location.replace(newLoc);
     }
 
+    const lastSlashIdx = window.location.href.lastIndexOf('/');
+    if (window.location.href.slice(lastSlashIdx, lastSlashIdx + 2) === '/#') {
+      window.stop();
+
+      var temp = window.location.href.split('');
+      temp.splice(lastSlashIdx, 1);
+      const newLoc = temp.join('');
+      window.location.replace(newLoc);
+    }
+
     // If the URL requested is /en/... redirect to /...
     if (window.location.href.includes('/en/') || window.location.href.endsWith('/en')) {
       window.stop(); // Stop processing this page, make sure no 404 rendering is done


### PR DESCRIPTION
E.g.
  .../newsroom/somepage/#someanchor
will be redirected into
  .../newsroom/somepage#someanchor

Fixes #23

## Changelog:
* Extend 404 handler to handle /# in URL

## Test URLs:
- Original: https://old.sunstar.com/newsroom/news/update-of-sunstars-esg-activities-for-2023/#progress-of-esg-activities-at-sunstar-during-2022
- Before: https://main--sunstar--sunstar-global.hlx.live/newsroom/update-of-sunstars-esg-activities-for-2023/#progress-of-esg-activities-at-sunstar-during-2022
- After: https://issue-23--sunstar--sunstar-global.hlx.live/newsroom/update-of-sunstars-esg-activities-for-2023/#progress-of-esg-activities-at-sunstar-during-2022
 