### PR TITLE
Fix cards image being cut issue on row variants

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -142,7 +142,7 @@ main .block.cards {
   margin-bottom: 3rem;
 }
 
-.cards .cards-card-image img {
+.cards:not(.row) .cards-card-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -338,8 +338,7 @@ main .cards.machine-parts .cards-card-body a > strong {
 
 /* Style for Row Cards */
 main .cards.row .cards-card-image {
-  width: auto;
-  height: 6rem;
+  width: 20%;
   flex-shrink: 0;
   margin: 0;
 }
@@ -352,8 +351,8 @@ main .block.cards.row > ul > li {
   display: flex;
   align-items: flex-start;
   margin: 0;
-  padding-bottom: 1rem;
   box-shadow: none;
+  gap: 1rem;
 }
 
 /* stylelint-disable-next-line no-descending-specificity */

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -84,7 +84,12 @@ main .block.cards {
   margin: 0 auto;
   text-align: left;
   color: var(--light-black);
+  padding: 20px;
   box-sizing: border-box;
+}
+
+.cards.row .cards-card-body {
+  padding: 0;
 }
 
 .cards.no-shadow .cards-card-body {

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -84,7 +84,6 @@ main .block.cards {
   margin: 0 auto;
   text-align: left;
   color: var(--light-black);
-  padding: 20px;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:


## Changelog:
_Please enter each change as a new bullet point_

## Test URLs:
- Original: https://www.sunstar.com/sustainability/environment/biodiversity
- Before: https://main--sunstar--sunstar-global.hlx.live/sustainability/environment/biodiversity
- After: https://cards-fix--sunstar--sunstar-global.hlx.live/sustainability/environment/biodiversity

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
**Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library


- [ ] New variations introduced in this PR
**Variation Name** :  For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
**Mixin Name** :  For e.g. _compact, white_
- [ ] Documented in sidekick library
