### PR TITLE
Add hreflang alternatives to sitemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Visual testing is integrated as a [Github workflow](https://github.com/sunstar-g
       ```
       env:
       TEST_PATHS: "/ /career/yuya-yoshisue /brands"
-      ```     
+      ```
 
 ⚠️  While proposing a PR with visual changes, please ensure that it has adequate visual testing coverage by adding impacted places at one or both places mentioned above.
 
@@ -76,3 +76,4 @@ Here are the steps to follow:
     ```
     await loadScript('/ext-libs/jslinq/jslinq.min.js');
     ```
+

--- a/README.md
+++ b/README.md
@@ -76,4 +76,3 @@ Here are the steps to follow:
     ```
     await loadScript('/ext-libs/jslinq/jslinq.min.js');
     ```
-

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,8 +1,16 @@
 version: 1
 auto-generated: true
 sitemaps:
-  default:
-    origin: https://www.sunstar.com
-    source: /query-index.json
-    destination: /sitemap.xml
+  sunstar:
+    default: en
     lastmod: YYYY-MM-DD
+    languages:
+      en:
+        source: /query-index.json?sheet=en-search
+        destination: /sitemap-en.xml
+        hreflang: en
+      ja:
+        source: /query-index.json?sheet=jp-search
+        destination: /sitemap-ja.xml
+        hreflang: ja
+        alternate: /jp/{path}

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.sunstar.com/sitemap.xml
+Sitemap: https://www.sunstar.com/sitemap-index.xml

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-en.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-cn.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-th.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-it.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-ja.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-id.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-engineering.com/sitemap-de.xml</loc>
+    </sitemap>
+</sitemapindex>

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,24 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-en.xml</loc>
+        <loc>https://www.sunstar.com/sitemap-en.xml</loc>
     </sitemap>
     <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-cn.xml</loc>
-    </sitemap>
-    <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-th.xml</loc>
-    </sitemap>
-    <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-it.xml</loc>
-    </sitemap>
-    <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-ja.xml</loc>
-    </sitemap>
-    <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-id.xml</loc>
-    </sitemap>
-    <sitemap>
-        <loc>https://www.sunstar-engineering.com/sitemap-de.xml</loc>
+        <loc>https://www.sunstar.com/sitemap-ja.xml</loc>
     </sitemap>
 </sitemapindex>


### PR DESCRIPTION
There are now 2 sitemaps: sitemap-ja.xml and sitemap-en.xml for the 2 languages. They are referenced into robots.txt via the new sitemap-index.xml

A sample of a generated sitemap looks like this:

```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>https://www.sunstar.com/jp/about/history</loc>
    <lastmod>2024-01-15</lastmod>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar.com/about/history"/>
    <xhtml:link rel="alternate" hreflang="ja" href="https://www.sunstar.com/jp/about/history"/>
    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.sunstar.com/about/history"/>
  </url>
  <url>
    <loc>https://www.sunstar.com/jp/terms</loc>
    <lastmod>2024-01-15</lastmod>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar.com/terms"/>
    <xhtml:link rel="alternate" hreflang="ja" href="https://www.sunstar.com/jp/terms"/>
    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.sunstar.com/terms"/>
  </url>
  ...
```

Fixes: #72 

Test URLs (for LHS):
* Before: https://main--sunstar--coderthoughts.hlx.live/about
* After: https://hreflangglb--sunstar--coderthoughts.hlx.live/about

The new sitemaps can be found here:
* https://hreflangglb--sunstar--coderthoughts.hlx.live/sitemap-en.xml
* https://hreflangglb--sunstar--coderthoughts.hlx.live/sitemap-ja.xml
