### PR TITLE
Added possibility to see the folders in DAM sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
       "id": "asset-library",
       "title": "DAM",
       "environments": ["edit"],
-      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html?rail=false",
       "isPalette": true,
       "includePaths": ["**.docx**"],
       "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:800px; height: calc(100vh - 60px)"


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after), along with a short summary of changes:


## Changelog:

_Please enter each change as a new bullet point_

## Test URLs:

- Original: https://www.sunstar.com/
- Before: https://main--sunstar--sunstar-global.aem.live/
- After: https://fe--sunstar--sunstar-global.aem.live/

## Library

- [ ] New Blocks introduced in this PR
      If yes, please provide details below
      **Block Name** : For e.g. _cards_
- [ ] Documented in sidekick library

- [ ] New variations introduced in this PR
      **Variation Name** : For e.g. _cards (grid)_
- [ ] Documented in sidekick library

- [ ] New mixins introduced in this PR
      **Mixin Name** : For e.g. _compact, white_
- [ ] Documented in sidekick library
